### PR TITLE
improve pipenv venv handling

### DIFF
--- a/examples/pipenv/.license-check.yaml
+++ b/examples/pipenv/.license-check.yaml
@@ -1,0 +1,4 @@
+allowedLicenses:
+- MIT License
+excludedPackages: []
+include: []

--- a/examples/pipenv/Pipfile
+++ b/examples/pipenv/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+texttable = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.8"

--- a/examples/pipenv/Pipfile.lock
+++ b/examples/pipenv/Pipfile.lock
@@ -1,0 +1,29 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "3d3f62b35ebfa21ce2675c440194ee2d6e777251c19b8090cd27af0e7a30bce8"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "texttable": {
+            "hashes": [
+                "sha256:ce0faf21aa77d806bbff22b107cc22cce68dc9438f97a2df32c93e9afa4ce436",
+                "sha256:f802f2ef8459058736264210f716c757cbf85007a30886d8541aa8c3404f1dda"
+            ],
+            "index": "pypi",
+            "version": "==1.6.3"
+        }
+    },
+    "develop": {}
+}

--- a/src/kontrolilo/base_checker.py
+++ b/src/kontrolilo/base_checker.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import abc
+import os
 from builtins import dict
 from logging import getLogger
 from os.path import abspath
@@ -35,12 +36,16 @@ class BaseLicenseChecker(BaseChecker):
 
         logger.debug('Running license checker command [%s]', license_checker_command)
 
+        environ = self.get_license_checker_env()
         result = run(license_checker_command, capture_output=True, cwd=directory,
-                     shell=True, text=True)
+                     env=environ, shell=True, text=True)
         logger.debug('Result of license checker command [%s]', result)
         result.check_returncode()
 
         return self.parse_packages(result.stdout, configuration, directory)
+
+    def get_license_checker_env(self):
+        return os.environ
 
     def consolidate_directories(self, filenames) -> List[str]:
         directories = []

--- a/src/kontrolilo/pipenv.py
+++ b/src/kontrolilo/pipenv.py
@@ -1,23 +1,28 @@
 # -*- coding: utf-8 -*-
+import os
 from json import loads
 from subprocess import run
 from typing import List
 
 from kontrolilo.base_checker import BaseLicenseChecker
-from kontrolilo.shared_main import shared_main
 from kontrolilo.configuration import Configuration
 from kontrolilo.configuration.package import Package
+from kontrolilo.shared_main import shared_main
 
 
 # TODO: ignore pip-licenses
 class PipenvLicenseChecker(BaseLicenseChecker):
     def prepare_directory(self, directory: str):
-        run('pipenv install -d', capture_output=True, check=True, cwd=directory, shell=True)
-        run("pipenv run pip install 'pip-licenses==3.3.1'", capture_output=True, check=True, cwd=directory,
+        run('pipenv install -d', capture_output=True, check=True, cwd=directory, env=self.get_license_checker_env(),
             shell=True)
+        run("pipenv run pip install 'pip-licenses==3.3.1'", capture_output=True, check=True, cwd=directory,
+            env=self.get_license_checker_env(), shell=True)
 
     def get_license_checker_command(self, directory: str) -> str:
         return 'pipenv run pip-licenses --format=json'
+
+    def get_license_checker_env(self):
+        return dict(os.environ, PIPENV_IGNORE_VIRTUALENVS='1')
 
     def parse_packages(self, output: str, configuration: Configuration, directory: str) -> List[Package]:
         values = loads(output)

--- a/src/kontrolilo/pipenv.py
+++ b/src/kontrolilo/pipenv.py
@@ -10,7 +10,6 @@ from kontrolilo.configuration.package import Package
 from kontrolilo.shared_main import shared_main
 
 
-# TODO: ignore pip-licenses
 class PipenvLicenseChecker(BaseLicenseChecker):
     def prepare_directory(self, directory: str):
         run('pipenv install -d', capture_output=True, check=True, cwd=directory, env=self.get_license_checker_env(),

--- a/tests/unit/test_base_check.py
+++ b/tests/unit/test_base_check.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 from os.path import join
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -89,22 +90,22 @@ class TestBaseLicenseChecker:
         run_mock.return_value = result_mock
 
         self.checker.load_installed_packages(self.directory, {})
-        run_mock.assert_called_once_with('echo \'Hello World!\'', capture_output=True, cwd=self.directory, shell=True,
-                                         text=True)
+        run_mock.assert_called_once_with('echo \'Hello World!\'', capture_output=True, cwd=self.directory,
+                                         env=os.environ, shell=True, text=True)
 
-    class Object(object):
-        pass
+        class Object(object):
+            pass
 
-    def test_run_returns_failure_on_no_config(self):
-        args = self.Object()
-        args.filenames = [join(self.directory.name, 'package.json')]
-        result = self.checker.run(args)
-        assert result == 1
+        def test_run_returns_failure_on_no_config(self):
+            args = self.Object()
+            args.filenames = [join(self.directory.name, 'package.json')]
+            result = self.checker.run(args)
+            assert result == 1
 
-    def test_run_returns_success(self):
-        Configuration(allowed_licenses=['BSD License', 'GPL', 'MIT License']).save_to_directory(self.directory.name)
+        def test_run_returns_success(self):
+            Configuration(allowed_licenses=['BSD License', 'GPL', 'MIT License']).save_to_directory(self.directory.name)
 
-        args = self.Object()
-        args.filenames = [join(self.directory.name, 'package.json')]
-        result = self.checker.run(args)
-        assert result == 0
+            args = self.Object()
+            args.filenames = [join(self.directory.name, 'package.json')]
+            result = self.checker.run(args)
+            assert result == 0

--- a/tests/unit/test_pipenv.py
+++ b/tests/unit/test_pipenv.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import os
 from tempfile import TemporaryDirectory
 from unittest.mock import patch, call
 
@@ -61,8 +61,8 @@ class TestPipenvLicenseChecker:
 
         self.checker.prepare_directory(self.directory.name)
         run_mock.assert_has_calls([
-            call('pipenv install -d', capture_output=True, check=True, cwd=self.directory.name, shell=True),
+            call('pipenv install -d', capture_output=True, check=True, cwd=self.directory.name,
+                 env=dict(os.environ, PIPENV_IGNORE_VIRTUALENVS='1'), shell=True),
             call("pipenv run pip install 'pip-licenses==3.3.1'", capture_output=True, check=True,
-                 cwd=self.directory.name,
-                 shell=True),
+                 cwd=self.directory.name, env=dict(os.environ, PIPENV_IGNORE_VIRTUALENVS='1'), shell=True),
         ])


### PR DESCRIPTION
when calling the hook from a Pipenv shell, a new shell is enforced to provide proper separation