### PR TITLE
Add support for yarn and clarify documentation of npm hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 ---
 repos:
-  - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.17.6
-    hooks:
-      - id: commitizen
-        stages: [commit-msg]
+  # - repo: https://github.com/commitizen-tools/commitizen
+  #   rev: v2.17.6
+  #   hooks:
+  #     - id: commitizen
+  #       stages: [commit-msg]
   - repo: https://github.com/frnmst/md-toc
     rev: 7.2.0
     hooks:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,31 +1,37 @@
 ---
 - id: license-check-configuration-lint
   name: Check the configuration files for pre-commit-license-check.
-  description: This hook scans the the gradle dependency list againt a configured list of allowed open source licenses.
+  description: This hook scans the the gradle dependency list against a configured list of allowed open source licenses.
   entry: license-check-configuration-lint
   files: '.*license-check.*\.yaml'
   language: python
 - id: license-check-gradle
   name: Check the licenses of the gradle environment.
-  description: This hook scans the the gradle dependency list againt a configured list of allowed open source licenses.
+  description: This hook scans the the gradle dependency list against a configured list of allowed open source licenses.
   entry: license-check-gradle
   files: build.gradle
   language: python
 - id: license-check-maven
   name: Check the licenses of the maven environment.
-  description: This hook scans the the maven dependency list againt a configured list of allowed open source licenses.
+  description: This hook scans the the maven dependency list against a configured list of allowed open source licenses.
   entry: license-check-maven
   files: pom.xml
   language: python
 - id: license-check-npm
   name: Check the licenses of the npm environment.
-  description: This hook scans the package. a configured list of allowed open source licenses.
+  description: This hook scans the node_modules directory against a configured list of allowed open source licenses.
   entry: license-check-npm
-  files: package.json
+  files: node_modules/*
   language: python
 - id: license-check-pipenv
   name: Check the licenses of the pipenv environment
   description: This hook scans the local Pipfile against a configured list of allowed open source licenses.
   entry: license-check-pipenv
   files: Pipfile
+  language: python
+- id: license-check-yarn
+  name: Check the licenses of the yarn environment
+  description: This hook scans the local yarn.lock file against a configured list of allowed open source licenses.
+  entry: license-check-yarn
+  files: node_modules/*
   language: python

--- a/docs/content/usage/pre-commit/_index.en.md
+++ b/docs/content/usage/pre-commit/_index.en.md
@@ -21,6 +21,7 @@ repos:
       - id: license-check-maven
       - id: license-check-npm
       - id: license-check-pipenv
+      - id: license-check-yarn
 ```
 
 ### Available Hooks

--- a/docs/content/usage/pre-commit/license-check-yarn.md
+++ b/docs/content/usage/pre-commit/license-check-yarn.md
@@ -1,5 +1,5 @@
 ---
-title: "license-check-npm"
+title: "license-check-yarn"
 weight: 40
 ---
 
@@ -9,5 +9,5 @@ weight: 40
 
 ### More info
 
-* [npm](https://www.npmjs.com/)
+* [yarn] (https://yarnpkg.com/)
 * [license-checker](https://www.npmjs.com/package/license-checker)

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
             'license-check-maven = kontrolilo.maven:main',
             'license-check-npm = kontrolilo.npm:main',
             'license-check-pipenv = kontrolilo.pipenv:main',
+            'license-check-yarn = kontrolilo.yarn:main',
         ],
     },
     dependency_links=[],

--- a/src/kontrolilo/yarn.py
+++ b/src/kontrolilo/yarn.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+import csv
+from subprocess import run
+from typing import List
+
+from kontrolilo.base_checker import BaseLicenseChecker
+from kontrolilo.shared_main import shared_main
+from kontrolilo.configuration.package import Package
+
+
+class YarnLicenseChecker(BaseLicenseChecker):
+    def prepare_directory(self, directory: str):
+        run('yarn install', capture_output=True, check=True, cwd=directory, shell=True)
+
+    def get_license_checker_command(self, directory: str) -> str:
+        # yes, we are using csv here. license-checker's json output does not build an array of licenses, which is
+        # pretty hard to parse.
+        return 'npx license-checker --csv'
+
+    def parse_packages(self, output: str, configuration: dict, directory: str) -> List[Package]:
+        packages = []
+        package_reader = csv.DictReader(output.splitlines())
+        for row in package_reader:
+            module = row['module name']
+            name = module
+            version = module
+            index = module.find('@')
+            if index > 0:
+                name = module[:index]
+                version = module[index + 1:]
+
+            packages.append(Package(name, version, row['license']))
+            print(packages)
+
+        return packages
+
+
+def main():
+    shared_main(YarnLicenseChecker())
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/test_yarn.py
+++ b/tests/integration/test_yarn.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from pathlib import Path
+from shutil import copy
+from typing import List
+
+from tests.integration.base_integration_test import IntegrationTestBase
+
+
+class TestNpmCheck(IntegrationTestBase):
+
+    def prepare_test_directory(self):
+        copy(Path(Path(__file__).parent, 'package.json').absolute(),
+             Path(self.directory.name, 'package.json').absolute())
+
+    def get_hook_id(self) -> str:
+        return 'license-check-npm'
+
+    def get_allowed_licenses(self) -> List[str]:
+        return ['ISC', 'MIT']

--- a/tests/unit/test_yarn.py
+++ b/tests/unit/test_yarn.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from tempfile import TemporaryDirectory
+from unittest.mock import patch, call
+
+from kontrolilo.configuration import Configuration
+from kontrolilo.configuration.package import Package
+from kontrolilo.npm import NpmLicenseChecker
+
+
+class TestNpmLicenseChecker:
+    DEMO_LICENSE_OUTPUT = \
+        '''"module name","license","repository"
+"xtend@4.0.2","MIT","https://github.com/Raynos/xtend"
+"y18n@4.0.0","ISC","https://github.com/yargs/y18n"
+"y18n@5.0.5","ISC","https://github.com/yargs/y18n"'''
+
+    def setup(self):
+        self.directory = TemporaryDirectory()
+        self.checker = YarnLicenseChecker()
+
+    @patch('kontrolilo.yarn.run')
+    def test_prepare_directory(self, run_mock):
+        run_mock.return_value = {}
+
+        with TemporaryDirectory() as directory:
+            self.checker.prepare_directory(directory)
+            run_mock.assert_has_calls([
+                call('yarn install', capture_output=True, check=True, cwd=directory, shell=True),
+            ])
+
+    def test_get_license_checker_command(self):
+        assert self.checker.get_license_checker_command('') == 'npx license-checker --csv'
+
+    def test_parse_packages(self):
+        packages = self.checker.parse_packages(self.DEMO_LICENSE_OUTPUT, Configuration(
+            allowed_licenses=[],
+            excluded_packages=[]
+        ), self.directory.name)
+        assert packages == [
+            Package('xtend', '4.0.2', 'MIT'),
+            Package('y18n', '4.0.0', 'ISC'),
+            Package('y18n', '5.0.5', 'ISC'),
+
+        ]


### PR DESCRIPTION
Hi! First time contributing to an open source repo so bear with me: 

Commitizen hook is commented out currently because it was failing on 

`Traceback (most recent call last):
  File "/Users/e.nichols/.cache/pre-commit/repoj_m_brhj/py_env-python3/bin/cz", line 5, in <module>
    from commitizen.cli import main
  File "/Users/e.nichols/.cache/pre-commit/repoj_m_brhj/py_env-python3/lib/python3.9/site-packages/commitizen/cli.py", line 9, in <module>
    from commitizen import commands, config
  File "/Users/e.nichols/.cache/pre-commit/repoj_m_brhj/py_env-python3/lib/python3.9/site-packages/commitizen/commands/__init__.py", line 1, in <module>
    from .bump import Bump
  File "/Users/e.nichols/.cache/pre-commit/repoj_m_brhj/py_env-python3/lib/python3.9/site-packages/commitizen/commands/bump.py", line 7, in <module>
    from commitizen.commands.changelog import Changelog
  File "/Users/e.nichols/.cache/pre-commit/repoj_m_brhj/py_env-python3/lib/python3.9/site-packages/commitizen/commands/changelog.py", line 6, in <module>
    from commitizen import changelog, factory, git, out
  File "/Users/e.nichols/.cache/pre-commit/repoj_m_brhj/py_env-python3/lib/python3.9/site-packages/commitizen/changelog.py", line 34, in <module>
    from jinja2 import Environment, PackageLoader
  File "/Users/e.nichols/.cache/pre-commit/repoj_m_brhj/py_env-python3/lib/python3.9/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/Users/e.nichols/.cache/pre-commit/repoj_m_brhj/py_env-python3/lib/python3.9/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/Users/e.nichols/.cache/pre-commit/repoj_m_brhj/py_env-python3/lib/python3.9/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File "/Users/e.nichols/.cache/pre-commit/repoj_m_brhj/py_env-python3/lib/python3.9/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/Users/e.nichols/.cache/pre-commit/repoj_m_brhj/py_env-python3/lib/python3.9/site-packages/markupsafe/__init__.py`

Which seems to be an issue with the jinja2 in the pyenv not being up to date to support marksafe. I'm not sure how to fix this.